### PR TITLE
rgb values 100 times too high when s == 0

### DIFF
--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -103,7 +103,7 @@ namespace ColorSpace {
 		double l = item->l / 100;
 
 		if (item->s == 0) {
-			color->r = color->g = color->b = item->l * 255;
+			color->r = color->g = color->b = item->l / 100 * 255;
 		}
 		else {
 			double temp1, temp2;


### PR DESCRIPTION
now correctly calculates rgb from hsl
```
farver::convert_colour(matrix(c(0, 0, 1), 1, 3), "hsl", "rgb")
#      [,1]  [,2]  [,3]
# [1,] 2.55 2.55 2.55
farver::convert_colour(matrix(c(0, 0, 50), 1, 3), "hsl", "rgb")
#      [,1]  [,2]  [,3]
# [1,] 127.5 127.5 127.5
farver::convert_colour(matrix(c(0, 0, 100), 1, 3), "hsl", "rgb")
#      [,1]  [,2]  [,3]
# [1,] 255 255 255

```