### PR TITLE
Feature: encode_colour() and _native() allow na_value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,6 @@ Suggests:
     testthat (>= 3.0.0)
 Encoding: UTF-8
 Roxygen: list(markdown=TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 SystemRequirements: C++11
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # farver (development version)
 
+* `encode_colour()` and `encode_native()` also accept a list of channel vectors.
+  If you compute your channels independently you don't need to `cbind()` them into
+  a contiguous matrix anymore, but rather you can `list()` them (#36, @zeehio).
+
 # farver 2.1.1
 
 * Added input checking to a range of functions to guard against segfaults with 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   If you compute your channels independently you don't need to `cbind()` them into
   a contiguous matrix anymore, but rather you can `list()` them (#36, @zeehio).
 
+* `encode_native()` is faster now. It avoids going through an intermediate character
+  vector representation (#375, @zeehio).
+
 # farver 2.1.1
 
 * Added input checking to a range of functions to guard against segfaults with 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,12 @@
   a contiguous matrix anymore, but rather you can `list()` them (#36, @zeehio).
 
 * `encode_native()` is faster now. It avoids going through an intermediate character
-  vector representation (#375, @zeehio).
+  vector representation (#37, @zeehio).
+
+* `encode_colour()` and `encode_native()` accept a `na_value` argument to specify
+  a color that can be used as a fallback if the color to convert contains `NA`s
+  or it can not be represented in the RGB space. (#38, @zeehio)
+
 
 # farver 2.1.1
 

--- a/R/encode.R
+++ b/R/encode.R
@@ -47,10 +47,10 @@ encode_colour <- function(colour, alpha = NULL, from = 'rgb', white = 'D65') {
   if (from != 'rgb') {
     white <- as_white_ref(white)
   }
-  encode_c(colour, alpha, colourspace_match(from), white)
+  encode_c(colour, alpha, colourspace_match(from), white, out_format = 1L)
 }
 
-encode_c <- function(colour, alpha, from, white) {
+encode_c <- function(colour, alpha, from, white, out_format = 1L) {
   # colour has zero colours:
   if ((is.matrix(colour) || is.data.frame(colour)) && nrow(colour) == 0) {
     return(character())
@@ -80,5 +80,9 @@ encode_c <- function(colour, alpha, from, white) {
       alpha <- NULL
     }
   }
-  .Call(`farver_encode_c`, colour, alpha, as.integer(from), white)
+  out_format <- as.integer(out_format)
+  if (out_format != 1L && out_format != 2L) {
+    stop("out_format must be 1L (for character) or 2L (for native)")
+  }
+  .Call(`farver_encode_c`, colour, alpha, as.integer(from), white, out_format)
 }

--- a/R/encode.R
+++ b/R/encode.R
@@ -6,7 +6,11 @@
 #' 
 #' @inheritSection convert_colour Handling of non-finite and out of bounds values
 #' 
-#' @inheritParams convert_colour
+#' @param colour A numeric matrix (or an object coercible to one) with colours 
+#' encoded in the rows and the different colour space values in the columns. For 
+#' all colourspaces except `'cmyk'` this will mean a matrix with three columns - 
+#' for `'cmyk'` it means four columns. Alternatively, `colour` may be a list of
+#' length three (or four for `'cmyk'`) numeric vectors of the same length.
 #' @param alpha A numeric vector between 0 and 1. Will be recycled to the number
 #' of rows in `colour`. If `NULL` or a single `NA` it will be ignored.
 #' @param from The input colour space. Allowed values are: `"cmy"`, 
@@ -47,18 +51,34 @@ encode_colour <- function(colour, alpha = NULL, from = 'rgb', white = 'D65') {
 }
 
 encode_c <- function(colour, alpha, from, white) {
-  if (nrow(colour) == 0) {
+  # colour has zero colours:
+  if ((is.matrix(colour) || is.data.frame(colour)) && nrow(colour) == 0) {
     return(character())
   }
+  # Colour has zero colours (given as a list of channels)
+  if (is.list(colour) && (length(colour) == 0 || length(colour[[1]]) == 0)) {
+    return(character())
+  }
+  # Colour is neither a list or a matrix, so let's coerce it
+  if (!is.matrix(colour) && !is.list(colour)) {
+    colour <- as.matrix(colour)
+  }
+  # How many colours do we have?
+  if (is.matrix(colour)) {
+    num_colours <- nrow(colour)
+  } else {
+    num_colours <- length(colour[[1]])
+  }
+
   if (!is.null(alpha)) {
     alpha <- alpha * 255
     if (length(alpha) == 0) {
       alpha <- NULL
     } else if (length(alpha) != 1) {
-      alpha <- rep_len(alpha, nrow(colour))
+      alpha <- rep_len(alpha, num_colours)
     } else if (is.na(alpha) || alpha == 1) {
       alpha <- NULL
     }
   }
-  .Call(`farver_encode_c`, as.matrix(colour), alpha, as.integer(from), white)
+  .Call(`farver_encode_c`, colour, alpha, as.integer(from), white)
 }

--- a/R/native.R
+++ b/R/native.R
@@ -32,14 +32,14 @@
 #' # Convert back
 #' decode_native(native_col)
 #' 
-encode_native <- function(colour, alpha = NULL, from = 'rgb', white = 'D65') {
+encode_native <- function(colour, alpha = NULL, from = 'rgb', white = 'D65', na_value = NA) {
   if (is.character(colour)) {
-    return(encode_native_c(colour))
+    return(encode_native_c(colour, na_value = na_value))
   }
   if (from != 'rgb') {
     white <- as_white_ref(white)
   }
-  encode_c(colour, alpha, colourspace_match(from), white, out_format = 2L)
+  encode_c(colour, alpha, colourspace_match(from), white, out_format = 2L, na_value = na_value)
 }
 
 #' @rdname native_encoding
@@ -48,8 +48,15 @@ decode_native <- function(colour) {
   decode_native_c(colour)
 } 
 
-encode_native_c <- function(colour) {
-  .Call(`farver_encode_native_c`, colour)
+encode_native_c <- function(colour, na_value = NA_character_) {
+  if (length(na_value) == 0) {
+    na_value <- NA_character_
+  }
+  if (length(na_value) > 1) {
+    stop("na_value must be a string")
+  }
+  na_value <- as.character(na_value)
+  .Call(`farver_encode_native_c`, colour, na_value)
 }
 decode_native_c <- function(colour) {
   .Call(`farver_decode_native_c`, as.integer(colour))

--- a/R/native.R
+++ b/R/native.R
@@ -12,10 +12,9 @@
 #' 
 #' @param colour For `encode_native` either a vector of hex-encoded 
 #' colours/colour names or a matrix encoding colours in any of the supported 
-#' colour spaces. If the  latter, the colours will be encoded to a hex string 
-#' using [encode_colour()] first. For `decode_native` it is a vector of 
+#' colour spaces. For `decode_native` it is a vector of 
 #' integers.
-#' @param ... Arguments passed on to [encode_colour()]
+#' @inheritParams encode_colour
 #' 
 #' @return `encode_native()` returns an integer vector and `decode_native()`
 #' returns a character vector, both matching the length of the input.
@@ -33,12 +32,16 @@
 #' # Convert back
 #' decode_native(native_col)
 #' 
-encode_native <- function(colour, ...) {
-  if (!is.character(colour)) {
-    colour <- encode_colour(colour, ...)
+encode_native <- function(colour, alpha = NULL, from = 'rgb', white = 'D65') {
+  if (is.character(colour)) {
+    return(encode_native_c(colour))
   }
-  encode_native_c(colour)
+  if (from != 'rgb') {
+    white <- as_white_ref(white)
+  }
+  encode_c(colour, alpha, colourspace_match(from), white, out_format = 2L)
 }
+
 #' @rdname native_encoding
 #' @export
 decode_native <- function(colour) {

--- a/man/encode_colour.Rd
+++ b/man/encode_colour.Rd
@@ -4,7 +4,13 @@
 \alias{encode_colour}
 \title{Encode colours into RGB hex-strings}
 \usage{
-encode_colour(colour, alpha = NULL, from = "rgb", white = "D65")
+encode_colour(
+  colour,
+  alpha = NULL,
+  from = "rgb",
+  white = "D65",
+  na_value = NA_character_
+)
 }
 \arguments{
 \item{colour}{A numeric matrix (or an object coercible to one) with colours
@@ -25,6 +31,11 @@ or \code{"oklch"} (Polar form of oklab)}
 \item{white}{The white reference of the input colour space. Will only have an
 effect for relative colour spaces such as Lab and luv. Any value accepted by
 \code{\link[=as_white_ref]{as_white_ref()}} allowed.}
+
+\item{na_value}{A valid colour string or \code{NA} to use when \code{colour} contains
+\code{NA} elements or is invalid in the RGB space. The general approach in farver
+is to carry \code{NA} values over, but if you want to mimick \code{\link[=col2rgb]{col2rgb()}} you should
+set \code{na_value = 'transparent'}, i.e. treat \code{NA} as transparent white.}
 }
 \value{
 A character vector with colours encoded as \verb{#RRGGBB(AA)}

--- a/man/encode_colour.Rd
+++ b/man/encode_colour.Rd
@@ -10,7 +10,8 @@ encode_colour(colour, alpha = NULL, from = "rgb", white = "D65")
 \item{colour}{A numeric matrix (or an object coercible to one) with colours
 encoded in the rows and the different colour space values in the columns. For
 all colourspaces except \code{'cmyk'} this will mean a matrix with three columns -
-for \code{'cmyk'} it means four columns.}
+for \code{'cmyk'} it means four columns. Alternatively, \code{colour} may be a list of
+length three (or four for \code{'cmyk'}) numeric vectors of the same length.}
 
 \item{alpha}{A numeric vector between 0 and 1. Will be recycled to the number
 of rows in \code{colour}. If \code{NULL} or a single \code{NA} it will be ignored.}

--- a/man/native_encoding.Rd
+++ b/man/native_encoding.Rd
@@ -6,7 +6,7 @@
 \alias{decode_native}
 \title{Convert to and from the R native colour representation}
 \usage{
-encode_native(colour, alpha = NULL, from = "rgb", white = "D65")
+encode_native(colour, alpha = NULL, from = "rgb", white = "D65", na_value = NA)
 
 decode_native(colour)
 }
@@ -28,6 +28,11 @@ or \code{"oklch"} (Polar form of oklab)}
 \item{white}{The white reference of the input colour space. Will only have an
 effect for relative colour spaces such as Lab and luv. Any value accepted by
 \code{\link[=as_white_ref]{as_white_ref()}} allowed.}
+
+\item{na_value}{A valid colour string or \code{NA} to use when \code{colour} contains
+\code{NA} elements or is invalid in the RGB space. The general approach in farver
+is to carry \code{NA} values over, but if you want to mimick \code{\link[=col2rgb]{col2rgb()}} you should
+set \code{na_value = 'transparent'}, i.e. treat \code{NA} as transparent white.}
 }
 \value{
 \code{encode_native()} returns an integer vector and \code{decode_native()}

--- a/man/native_encoding.Rd
+++ b/man/native_encoding.Rd
@@ -6,18 +6,28 @@
 \alias{decode_native}
 \title{Convert to and from the R native colour representation}
 \usage{
-encode_native(colour, ...)
+encode_native(colour, alpha = NULL, from = "rgb", white = "D65")
 
 decode_native(colour)
 }
 \arguments{
 \item{colour}{For \code{encode_native} either a vector of hex-encoded
 colours/colour names or a matrix encoding colours in any of the supported
-colour spaces. If the  latter, the colours will be encoded to a hex string
-using \code{\link[=encode_colour]{encode_colour()}} first. For \code{decode_native} it is a vector of
+colour spaces. For \code{decode_native} it is a vector of
 integers.}
 
-\item{...}{Arguments passed on to \code{\link[=encode_colour]{encode_colour()}}}
+\item{alpha}{A numeric vector between 0 and 1. Will be recycled to the number
+of rows in \code{colour}. If \code{NULL} or a single \code{NA} it will be ignored.}
+
+\item{from}{The input colour space. Allowed values are: \code{"cmy"},
+\code{"cmyk"}, \code{"hsl"}, \code{"hsb"}, \code{"hsv"}, \code{"lab"} (CIE L*ab), \code{"hunterlab"}
+(Hunter Lab), \code{"oklab"}, \code{"lch"} (CIE Lch(ab) / polarLAB), \code{"luv"},
+\code{"rgb"} (sRGB), \code{"xyz"}, \code{"yxy"} (CIE xyY), \code{"hcl"} (CIE Lch(uv) / polarLuv),
+or \code{"oklch"} (Polar form of oklab)}
+
+\item{white}{The white reference of the input colour space. Will only have an
+effect for relative colour spaces such as Lab and luv. Any value accepted by
+\code{\link[=as_white_ref]{as_white_ref()}} allowed.}
 }
 \value{
 \code{encode_native()} returns an integer vector and \code{decode_native()}

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -49,16 +49,51 @@ inline std::string prepare_code(const char* col) {
   return code;
 }
 
+struct colour_channels {
+  int n;
+  int *colour_i1;
+  int *colour_i2;
+  int *colour_i3;
+  int *colour_i4;
+  double *colour_d1;
+  double *colour_d2;
+  double *colour_d3;
+  double *colour_d4;
+  bool colour_is_int;
+};
+
+static void get_input_channels(struct colour_channels *cc, SEXP colour, int n_channels) {
+  if (Rf_isMatrix(colour)) {
+    cc->colour_is_int = Rf_isInteger(colour);
+    if (Rf_ncols(colour) < n_channels) {
+      Rf_errorcall(R_NilValue, "Colour in this format must contain at least %i columns", n_channels);
+    }
+    cc->n = Rf_nrows(colour);
+    if (cc->colour_is_int) {
+      cc->colour_i1 = INTEGER(colour);
+      cc->colour_i2 = cc->colour_i1 + cc->n;
+      cc->colour_i3 = cc->colour_i1 + 2*cc->n;
+      cc->colour_i4 = cc->colour_i1 + 3*cc->n;
+    } else {
+      cc->colour_d1 = REAL(colour);
+      cc->colour_d2 = cc->colour_d1 + cc->n;
+      cc->colour_d3 = cc->colour_d1 + 2*cc->n;
+      cc->colour_d4 = cc->colour_d1 + 3*cc->n;
+    }
+  } else {
+    Rf_error("invalid input format, expected a matrix");
+  }
+  return;
+}
+
 template <typename From>
 SEXP encode_impl(SEXP colour, SEXP alpha, SEXP white) {
-  int n_channels = dimension<From>();
-  if (Rf_ncols(colour) < n_channels) {
-    Rf_errorcall(R_NilValue, "Colour in this format must contain at least %i columns", n_channels);
-  }
   static ColorSpace::Rgb rgb;
+  struct colour_channels cc;
+  int n_channels = dimension<From>();
+  get_input_channels(&cc, colour, n_channels);
   ColorSpace::XyzConverter::SetWhiteReference(REAL(white)[0], REAL(white)[1], REAL(white)[2]);
-  int n = Rf_nrows(colour);
-  SEXP codes = PROTECT(Rf_allocVector(STRSXP, n));
+  SEXP codes = PROTECT(Rf_allocVector(STRSXP, cc.n));
   bool has_alpha = !Rf_isNull(alpha);
   char alpha1 = '\0';
   char alpha2 = '\0';
@@ -90,25 +125,13 @@ SEXP encode_impl(SEXP colour, SEXP alpha, SEXP white) {
   } else {
     buf = buffer;
   }
-  int offset1 = 0;
-  int offset2 = offset1 + n;
-  int offset3 = offset2 + n;
-  int offset4 = offset3 + n;
   
-  int* colour_i = NULL;
-  double* colour_d = NULL;
-  bool colour_is_int = Rf_isInteger(colour);
   int num;
-  if (colour_is_int) {
-    colour_i = INTEGER(colour);
-  } else {
-    colour_d = REAL(colour);
-  }
-  for (int i = 0; i < n; ++i) {
-    if (colour_is_int) {
-      fill_rgb<From>(&rgb, colour_i[offset1 + i], colour_i[offset2 + i], colour_i[offset3 + i], n_channels == 4 ? colour_i[offset4 + i] : 0);
+  for (int i = 0; i < cc.n; ++i) {
+    if (cc.colour_is_int) {
+      fill_rgb<From>(&rgb, cc.colour_i1[i], cc.colour_i2[i], cc.colour_i3[i], n_channels == 4 ? cc.colour_i4[i]: 0);
     } else {
-      fill_rgb<From>(&rgb, colour_d[offset1 + i], colour_d[offset2 + i], colour_d[offset3 + i], n_channels == 4 ? colour_d[offset4 + i] : 0.0);
+      fill_rgb<From>(&rgb, cc.colour_d1[i], cc.colour_d2[i], cc.colour_d3[i], n_channels == 4 ? cc.colour_d4[i] : 0.0);
     }
     if (!rgb.valid) {
       SET_STRING_ELT(codes, i, R_NaString);
@@ -160,11 +183,9 @@ SEXP encode_impl(SEXP colour, SEXP alpha, SEXP white) {
 
 template<>
 SEXP encode_impl<ColorSpace::Rgb>(SEXP colour, SEXP alpha, SEXP white) {
-  if (Rf_ncols(colour) < 3) {
-    Rf_errorcall(R_NilValue, "Colour in RGB format must contain at least 3 columns");
-  }
-  int n = Rf_nrows(colour);
-  SEXP codes = PROTECT(Rf_allocVector(STRSXP, n));
+  struct colour_channels cc;
+  get_input_channels(&cc, colour, 3);
+  SEXP codes = PROTECT(Rf_allocVector(STRSXP, cc.n));
   bool has_alpha = !Rf_isNull(alpha);
   char alpha1 = '\0';
   char alpha2 = '\0';
@@ -196,21 +217,14 @@ SEXP encode_impl<ColorSpace::Rgb>(SEXP colour, SEXP alpha, SEXP white) {
   } else {
     buf = buffer;
   }
-  int offset1 = 0;
-  int offset2 = offset1 + n;
-  int offset3 = offset2 + n;
   
-  int* colour_i = NULL;
-  double* colour_d = NULL;
-  bool colour_is_int = Rf_isInteger(colour);
   int num;
-  if (colour_is_int) {
+  if (cc.colour_is_int) {
     int r, g, b;
-    colour_i = INTEGER(colour);
-    for (int i = 0; i < n; ++i) {
-      r = colour_i[offset1 + i];
-      g = colour_i[offset2 + i];
-      b = colour_i[offset3 + i];
+    for (int i = 0; i < cc.n; ++i) {
+      r = cc.colour_i1[i];
+      g = cc.colour_i2[i];
+      b = cc.colour_i3[i];
       if (r == R_NaInt || g == R_NaInt || b == R_NaInt) {
         SET_STRING_ELT(codes, i, R_NaString);
         continue;
@@ -251,11 +265,10 @@ SEXP encode_impl<ColorSpace::Rgb>(SEXP colour, SEXP alpha, SEXP white) {
     }
   } else {
     double r, g, b;
-    colour_d = REAL(colour);
-    for (int i = 0; i < n; ++i) {
-      r = colour_d[offset1 + i];
-      g = colour_d[offset2 + i];
-      b = colour_d[offset3 + i];
+    for (int i = 0; i < cc.n; ++i) {
+      r = cc.colour_d1[i];
+      g = cc.colour_d2[i];
+      b = cc.colour_d3[i];
       if (!(R_finite(r) && R_finite(g) && R_finite(b))) {
         SET_STRING_ELT(codes, i, R_NaString);
         continue;

--- a/src/encode.h
+++ b/src/encode.h
@@ -36,7 +36,7 @@ typedef std::unordered_map<std::string, rgb_colour> ColourMap;
 // Defined in init.cpp
 ColourMap& get_named_colours();
 
-SEXP encode_c(SEXP colour, SEXP alpha, SEXP from, SEXP white);
+SEXP encode_c(SEXP colour, SEXP alpha, SEXP from, SEXP white, SEXP out_fmt);
 SEXP decode_c(SEXP codes, SEXP alpha, SEXP to, SEXP white, SEXP na);
 SEXP encode_channel_c(SEXP codes, SEXP channel, SEXP value, SEXP space, SEXP op, SEXP white, SEXP na);
 SEXP decode_channel_c(SEXP codes, SEXP channel, SEXP space, SEXP white, SEXP na);

--- a/src/encode.h
+++ b/src/encode.h
@@ -36,12 +36,12 @@ typedef std::unordered_map<std::string, rgb_colour> ColourMap;
 // Defined in init.cpp
 ColourMap& get_named_colours();
 
-SEXP encode_c(SEXP colour, SEXP alpha, SEXP from, SEXP white, SEXP out_fmt);
+SEXP encode_c(SEXP colour, SEXP alpha, SEXP from, SEXP white, SEXP out_fmt, SEXP na_value);
 SEXP decode_c(SEXP codes, SEXP alpha, SEXP to, SEXP white, SEXP na);
 SEXP encode_channel_c(SEXP codes, SEXP channel, SEXP value, SEXP space, SEXP op, SEXP white, SEXP na);
 SEXP decode_channel_c(SEXP codes, SEXP channel, SEXP space, SEXP white, SEXP na);
 SEXP load_colour_names_c(SEXP name, SEXP value);
-SEXP encode_native_c(SEXP color);
+SEXP encode_native_c(SEXP color, SEXP na_value);
 SEXP decode_native_c(SEXP native);
 
 template <typename Space>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -15,7 +15,7 @@ ColourMap& get_named_colours() {
 static const R_CallMethodDef CallEntries[] = {
   {"farver_convert_c", (DL_FUNC) &convert_c, 5},
   {"farver_compare_c", (DL_FUNC) &compare_c, 8},
-  {"farver_encode_c", (DL_FUNC) &encode_c, 4},
+  {"farver_encode_c", (DL_FUNC) &encode_c, 5},
   {"farver_decode_c", (DL_FUNC) &decode_c, 5},
   {"farver_encode_channel_c", (DL_FUNC) &encode_channel_c, 7},
   {"farver_decode_channel_c", (DL_FUNC) &decode_channel_c, 5},

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -15,12 +15,12 @@ ColourMap& get_named_colours() {
 static const R_CallMethodDef CallEntries[] = {
   {"farver_convert_c", (DL_FUNC) &convert_c, 5},
   {"farver_compare_c", (DL_FUNC) &compare_c, 8},
-  {"farver_encode_c", (DL_FUNC) &encode_c, 5},
+  {"farver_encode_c", (DL_FUNC) &encode_c, 6},
   {"farver_decode_c", (DL_FUNC) &decode_c, 5},
   {"farver_encode_channel_c", (DL_FUNC) &encode_channel_c, 7},
   {"farver_decode_channel_c", (DL_FUNC) &decode_channel_c, 5},
   {"farver_load_colour_names_c", (DL_FUNC) &load_colour_names_c, 2},
-  {"farver_encode_native_c", (DL_FUNC) &encode_native_c, 1},
+  {"farver_encode_native_c", (DL_FUNC) &encode_native_c, 2},
   {"farver_decode_native_c", (DL_FUNC) &decode_native_c, 1},
   {NULL, NULL, 0}
 };

--- a/tests/testthat/test-comparison.R
+++ b/tests/testthat/test-comparison.R
@@ -1,5 +1,3 @@
-context("comparison")
-
 spectrum <- unname(t(col2rgb(rainbow(10))))
 spectrum2 <- unname(t(col2rgb(heat.colors(5))))
 reconvert <- function(data, space) {

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -1,5 +1,3 @@
-context("conversion")
-
 spectrum <- unname(t(col2rgb(rainbow(10))))
 reconvert <- function(data, space) {
   unname(round(convert_colour(convert_colour(data, 'rgb', space), space, 'rgb')))

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -22,3 +22,12 @@ test_that("alpha gets encoded correctly", {
   alpha_col <- encode_colour(cols_dec[1:6,], alpha = seq(0, 1, length.out = 6))
   expect_equal(substr(alpha_col, 8, 9), c("00", "33", "66", "99", "CC", ""))
 })
+
+test_that("colours can be encoded from a list of channels", {
+  cols_cmy <- convert_colour(cols_dec, 'rgb', 'cmy')
+  expect_equal(encode_colour(list(cols_dec[,1], cols_dec[,2], cols_dec[,3])), cols)
+  expect_equal(encode_colour(data.frame(cols_dec[,1], cols_dec[,2], cols_dec[,3])), cols)
+  expect_equal(encode_colour(list(cols_cmy[,1], cols_cmy[,2], cols_cmy[,3]), from = 'cmy'), cols)
+  expect_equal(encode_colour(data.frame(cols_cmy[,1], cols_cmy[,2], cols_cmy[,3]), from = 'cmy'), cols)
+})
+

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -51,3 +51,22 @@ test_that("colours can be encoded from a list of channels", {
   expect_equal(encode_colour(data.frame(cols_cmy[,1], cols_cmy[,2], cols_cmy[,3]), from = 'cmy'), cols)
 })
 
+
+test_that("can provide a colour to be used when NA are found", {
+  na_value <- "red"
+  cols_dec_na <- cols_dec
+  cols_dec_na[2,3] <- NA
+  cols_na <- cols
+  cols_na[2] <- NA
+  
+  expect_equal(encode_colour(cols_dec_na), cols_na)
+  cols_na[2] <- na_value
+  expect_equal(encode_colour(cols_dec_na, na_value = na_value), cols_na)
+  
+  native_cols_na <- native_cols
+  native_cols_na[2] <- NA
+  expect_equal(encode_native(cols_dec_na), native_cols_na)
+  native_cols_na[2] <- farver::encode_native(na_value)
+  expect_equal(encode_native(cols_dec_na, na_value = na_value), native_cols_na)
+})
+

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -1,6 +1,7 @@
 cols <- c("#404040", "#8FBC8F", "#FFFFE0", "#7AC5CD", "#66CDAA", "#1E90FF", 
   "#CDC0B0", "#CD0000", "#7A67EE", "#FFFACD")
 cols_dec <- decode_colour(cols)
+native_cols <- encode_native(cols)
 
 test_that("colours can be encoded", {
   expect_equal(encode_colour(cols_dec), cols)
@@ -22,6 +23,25 @@ test_that("alpha gets encoded correctly", {
   alpha_col <- encode_colour(cols_dec[1:6,], alpha = seq(0, 1, length.out = 6))
   expect_equal(substr(alpha_col, 8, 9), c("00", "33", "66", "99", "CC", ""))
 })
+
+
+
+test_that("colours can be encoded to native", {
+  expect_equal(encode_native(cols_dec), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'cmy'), from = 'cmy'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'cmyk'), from = 'cmyk'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'hsl'), from = 'hsl'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'hsb'), from = 'hsb'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'hsv'), from = 'hsv'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'lab'), from = 'lab'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'hunterlab'), from = 'hunterlab'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'lch'), from = 'lch'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'luv'), from = 'luv'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'xyz'), from = 'xyz'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'yxy'), from = 'yxy'), native_cols)
+  expect_equal(encode_native(convert_colour(cols_dec, 'rgb', 'hcl'), from = 'hcl'), native_cols)
+})
+
 
 test_that("colours can be encoded from a list of channels", {
   cols_cmy <- convert_colour(cols_dec, 'rgb', 'cmy')


### PR DESCRIPTION
Built on top of #37 and #36 (please review those first), this pull request allows for `encode_colour()` to pass a `na_value`.

Besides being a convenience feature, it also enables me to reduce passes or creating copies of larger vectors.

I am aiming to improve performance in how scale mapping works in ggplot2 with larger vectors. Related to https://github.com/tidyverse/ggplot2/issues/4989